### PR TITLE
Adds symbols from pokey_talon that have symmetry with cursorless commands

### DIFF
--- a/src/cursorless_symbols.talon
+++ b/src/cursorless_symbols.talon
@@ -1,0 +1,50 @@
+empty round: "()"
+empty square: "[]"
+empty curly: "{}"
+empty diamond: "<>"
+empty quad: '""'
+empty twin: "''"
+empty escaped quad: '\\"\\"'
+empty escaped twin: "\\'\\'"
+empty escaped round: "\\(\\)"
+empty escaped curly: "\\{{\\}}"
+tween <user.symbol_key>: user.insert_between("{symbol_key}", "{symbol_key}")
+quad: user.insert_between('"', '"')
+twin: user.insert_between("'", "'")
+ski: user.insert_between("`", "`")
+escaped quad: user.insert_between('\\"', '\\"')
+escaped twin: user.insert_between("\\'", "\\'")
+round: user.insert_between("(", ")")
+escaped round: user.insert_between("\\(", "\\)")
+escaped curly: user.insert_between("\\{{", "\\}}")
+square: user.insert_between("[", "]")
+curly: user.insert_between("{", "}")
+diamond: user.insert_between("<", ">")
+(diamond | angle) that:
+    text = edit.selected_text()
+    user.paste("<{text}>")
+(curly | lace) that:
+    text = edit.selected_text()
+    user.paste("{{{text}}}")
+(round | leper) that:
+    text = edit.selected_text()
+    user.paste("({text})")
+(double | quad) that:
+    text = edit.selected_text()
+    user.paste("'{text}'")
+(double quote | dubquote) that:
+    text = edit.selected_text()
+    user.paste('"{text}"')
+(single | twin) that:
+    text = edit.selected_text()
+    user.paste("'{text}'")
+
+big round:
+    insert("()")
+    key(left enter)
+big square:
+    insert("[]")
+    key(left enter)
+big curly:
+    insert("{}")
+    key(left enter)


### PR DESCRIPTION
I copied these from [pokey_talon](https://github.com/pokey/pokey_talon/blob/main/plugin/symbols/symbols.talon) since it would be nice to have access to these if you have cursorless installed. @pokey - I hope you don't mind!